### PR TITLE
优化监听vm刷新组件的状态

### DIFF
--- a/app/src/main/java/com/byl/mvvm/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/byl/mvvm/ui/main/MainActivity.kt
@@ -48,11 +48,15 @@ class MainActivity : BaseActivity<MainViewModel, ActivityMainBinding>() {
 
     override fun initVM() {
         vm.articlesData.observe(this, Observer {
-            v.refreshLayout.finishRefresh()
-            v.refreshLayout.finishLoadMore()
             if (page == 0) list!!.clear()
             it.datas?.let { it1 -> list!!.addAll(it1) }
             adapter!!.notifyDataSetChanged()
+        })
+        vm.isShowLoading.observe(this, Observer {
+            if(!it){
+                v.refreshLayout.finishRefresh()
+                v.refreshLayout.finishLoadMore()
+            }
         })
     }
 


### PR DESCRIPTION
当刷新数据失败时，refreshlayout的状态会回不去